### PR TITLE
Fix postprocessing for incomplete runs

### DIFF
--- a/cpaeds/postprocessing.py
+++ b/cpaeds/postprocessing.py
@@ -29,7 +29,7 @@ class postprocessing(object):
         self.energy_map = self.initialise_energy_map()
         self.energy_runs = []
 
-    def create_ana_dir(self):
+    def create_ana_dir(self, NOMD):
         """
         Creates a folder (ene_ana) with the argument files for gromos++ ene_ana and dfmult.
         """
@@ -40,12 +40,12 @@ class postprocessing(object):
         parent = os.getcwd()
         with set_directory(f"{parent}/ene_ana"):
             copy_lib_file(f"{parent}/ene_ana",'ene_ana.md++.lib')
-            ene_ana_body =  build_ene_ana(self.config,self.config['simulation']['parameters']['NRUN'])
+            ene_ana_body =  build_ene_ana(self.config,NOMD)
             write_file2(ene_ana_body,'ene_ana.arg')
             df_file_body = build_dfmult_file(self.config)
             write_file2(df_file_body,'df.arg')
 
-    def create_rmsd_dir(self):
+    def create_rmsd_dir(self, NOMD):
         """
         Creates a folder (rmsd) with the argument file for gromos++ rmsd.
         """
@@ -55,7 +55,7 @@ class postprocessing(object):
             pass
         parent = os.getcwd()
         with set_directory(f"{parent}/rmsd"):
-            rmsd_body = build_rmsd(self.config,self.config['simulation']['parameters']['NRUN'])
+            rmsd_body = build_rmsd(self.config,NOMD)
             write_file2(rmsd_body,'rmsd.arg')
 
     def create_output_dir(self):
@@ -223,9 +223,9 @@ class postprocessing(object):
                                         logger.info(f"Run in {dir} unfinished.")
                                     #rmsd & ene ana
                                     self.offsets_sp(i)
-                                    self.create_ana_dir()
+                                    self.create_ana_dir(NOMD=NOMD)
                                     self.run_ene_ana()
-                                    self.create_rmsd_dir()
+                                    self.create_rmsd_dir(NOMD=NOMD)
                                     self.run_rmsd()
                     #writing output                    
                     self.create_output_dir()

--- a/cpaeds/postprocessing.py
+++ b/cpaeds/postprocessing.py
@@ -70,7 +70,31 @@ class postprocessing(object):
         with set_directory(f"{parent}/results"):
             output_body = build_output(self.config,self.fraction_list,self.dF_list,self.rmsd_list)
             write_file2(output_body,'results.out')
-            np.save('energies.npy', np.array(self.energy_runs), allow_pickle=False)
+            harmonizedEnergyArray = self.harmonizeEnergyArray(self.energy_runs)
+            np.save('energies.npy', harmonizedEnergyArray, allow_pickle=False)
+
+    def harmonizeEnergyArray(self, l: list):
+        """
+        Harmonizes the length of a given list of lists containing energies by padding the 3rd dimension of the list with np.nan.
+
+        This is needed to use np.save on unfinished runs if there are some runs which are more finished than others.
+
+        Args:
+            l (list): list of lists with three dimensions: (runs, states, energies)
+        """
+
+        array_list = []
+
+        for run in l:
+            array_list.append(np.array(run))
+
+        maxLen = max([len(a[-1]) for a in array_list])
+
+        for i, run in enumerate(array_list):
+            paddedArray = np.pad(run, [(0,0), (0, maxLen - len(run[0]))], 'constant', constant_values=np.nan)
+            array_list[i] = paddedArray
+
+        return np.array(array_list)
 
     def initialise_energy_map(self):
         """

--- a/cpaeds/postprocessing_parallel.py
+++ b/cpaeds/postprocessing_parallel.py
@@ -30,7 +30,7 @@ class postprocessing_parallel(object):
         self.energy_map = self.initialise_energy_map()
         self.energy_runs = []
 
-    def create_ana_dir(self):
+    def create_ana_dir(self, NOMD):
         """
         Creates a folder (ene_ana) with the argument files for gromos++ ene_ana and dfmult.
         """
@@ -41,12 +41,12 @@ class postprocessing_parallel(object):
         parent = os.getcwd()
         with set_directory(f"{parent}/ene_ana"):
             copy_lib_file(f"{parent}/ene_ana",'ene_ana.md++.lib')
-            ene_ana_body =  build_ene_ana(self.config,self.config['simulation']['parameters']['NRUN'])
+            ene_ana_body =  build_ene_ana(self.config,NOMD)
             write_file2(ene_ana_body,'ene_ana.arg')
             df_file_body = build_dfmult_file(self.config)
             write_file2(df_file_body,'df.arg')
 
-    def create_rmsd_dir(self):
+    def create_rmsd_dir(self, NOMD):
         """
         Creates a folder (rmsd) with the argument file for gromos++ rmsd.
         """
@@ -56,7 +56,7 @@ class postprocessing_parallel(object):
             pass
         parent = os.getcwd()
         with set_directory(f"{parent}/rmsd"):
-            rmsd_body = build_rmsd(self.config,self.config['simulation']['parameters']['NRUN'])
+            rmsd_body = build_rmsd(self.config,NOMD)
             write_file2(rmsd_body,'rmsd.arg')
 
     def create_output_dir(self):
@@ -231,9 +231,9 @@ class postprocessing_parallel(object):
                 logger.info(f"Run in {dir} unfinished.")
             #rmsd & ene ana
             self.offsets_sp(i)
-            self.create_ana_dir()
+            self.create_ana_dir(NOMD=NOMD)
             self.run_ene_ana()
-            self.create_rmsd_dir()
+            self.create_rmsd_dir(NOMD=NOMD)
             self.run_rmsd()
 
     def get_results(self):


### PR DESCRIPTION
## Description
Previously, when running postprocessing on unfinished runs, the number of finished runs was not passed along correctly and therefore ene_ana throw an error.

This PR implements the correct handling of incomplete runs.

Additionally, `np.save` was throwing errors when parsing runs with different amounts of datapoints (for example if one run has finished 50/100 parts and the other one 48/100). This PR implements a fix where the arrays are padded with `np.nan` to have equal lengths in all dimensions.

## Questions
- [ ] Adding nan values to the energies.npy file might not work properly for statistical runs (needs testing)

## Status
- [x] Tested on unfinished runs
- [x] Tested on finished runs
- [x] Plotting tested
- [x] Ready to go